### PR TITLE
feat: Add support for optional explicit subric per pager

### DIFF
--- a/src/components/callsign/New.vue
+++ b/src/components/callsign/New.vue
@@ -67,6 +67,18 @@
 <script>
 	export default {
 		created() {
+		function formatSubric(subric) {
+			if (subric == null) {
+				return ""
+			}
+			switch (subric) {
+				case 0: return "A"
+				case 1: return "B"
+				case 2: return "C"
+				case 3: return "D"
+				default: return ""
+			}
+		}
 			this.$http.get('users').then(response => {
 				response.body.forEach(user => {
 					this.formData.users.push({name: user.name});
@@ -81,7 +93,7 @@
 					let pagerNumbers = '';
 					let pagerNames = '';
 					response.body.pagers.forEach(pager => {
-						pagerNumbers += this.$helpers.zeroPad(pager.number, 7) + '\n';
+						pagerNumbers += this.$helpers.zeroPad(pager.number, 7) + formatSubric(pager.subric) + '\n';
 						pagerNames += pager.name + '\n';
 					});
 
@@ -128,6 +140,21 @@
 		},
 		methods: {
 			submitForm(event) {
+
+				function getSubric(number) {
+					if (number == null || number.trim().length < 2) {
+						return null
+					}
+
+					switch (number.slice(-1).toUpperCase()) {
+							case "A": return 0
+							case "B": return 1
+							case "C": return 2
+							case "D": return 3
+							default: return null
+					}
+				}
+
 				event.preventDefault();
 
 				// check for input in all fields
@@ -139,11 +166,13 @@
 				let pagerNames = this.form.pager.names.split('\n');
 				let pagers = [];
 				for (let i = 0; i < pagerNumbers.length; i++) {
-					let item = {};
-					item.number = pagerNumbers[i];
-					item.name = pagerNames[i];
+					let subric = getSubric(pagerNumbers[i])
 
-					pagers.push(item);
+					pagers.push({
+							number: subric == null ? pagerNumbers[i] : pagerNumbers[i].slice(0, -1),
+							name: pagerNames[i],
+							subric: subric,
+					});
 				}
 
 				let ownerNames = [];

--- a/src/components/callsign/Overview.vue
+++ b/src/components/callsign/Overview.vue
@@ -86,6 +86,20 @@
 		},
 		methods: {
 			loadData() {
+
+				function formatSubric(subric) {
+					if (subric == null) {
+						return ""
+					}
+					switch (subric) {
+							case 0: return "A"
+							case 1: return "B"
+							case 2: return "C"
+							case 3: return "D"
+							default: return ""
+					}
+				}
+
 				this.running = true;
 				this.$http.get('callsigns').then(response => {
 					// success --> save new data
@@ -94,7 +108,7 @@
 						// add pager list
 						if (this.$store.getters.user.admin) {
 							let pagerText = [];
-							callsign.pagers.forEach(pager => pagerText.push(pager.name + ' (' + this.$helpers.zeroPad(pager.number, 7) + ')'));
+							callsign.pagers.forEach(pager => pagerText.push(pager.name + ' (' + this.$helpers.zeroPad(pager.number, 7) + formatSubric(pager.subric) + ')'));
 							callsign.pagers = pagerText.join(', ');
 						} else {
 							callsign.pagers = '---';


### PR DESCRIPTION
With this small feature it is possible to specify an optional explicit SubRIC (A-D) when creating pagers and assigning RICs. If a SubRIC is set, this will override the default SubRIC (ALPHANUM = 3) for an individual call. This feature therefore only works for pagers other than Skyper. (Transmissions of Rubrics/News/Time/StationId are not affected).

Since specifying the SubRIC is optional, all subscribers/pagers currently stored in DAPNET will work as before.

Since I'm not a vue.js expert, maybe someone can take a look at the code to see if anything can be done better? I couldn't test the frontend locally either unfortunately, so the PR is more meant as a proposal.